### PR TITLE
Make sure the plugin can produce output for en-* locales.

### DIFF
--- a/JavaScriptFileType.js
+++ b/JavaScriptFileType.js
@@ -102,8 +102,8 @@ JavaScriptFileType.prototype.write = function(translations, locales) {
         resources = this.extracted.getAll(),
         db = this.project.db,
         translationLocales = locales.filter(function(locale) {
-            return locale !== this.project.sourceLocale && locale !== this.project.pseudoLocale && !this.API.isPseudoLocale(locale);
-        }.bind(this));;
+            return locale !== this.project.sourceLocale && locale !== this.project.pseudoLocale;
+        }.bind(this));
 
     for (var i = 0; i < resources.length; i++) {
         res = resources[i];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-javascript",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "main": "./JavaScriptFileType.js",
     "description": "A loctool plugin that knows how to process JS files",
     "license": "Apache-2.0",


### PR DESCRIPTION
Previously, these were filtered out of the target locales erroneously because they are generated by a pseudolocale.