### PR TITLE
Parse parameter lists with extra trailing comma properly

### DIFF
--- a/JavaScriptFile.js
+++ b/JavaScriptFile.js
@@ -148,7 +148,7 @@ JavaScriptFile.prototype.parse = function(data) {
     this.resourceIndex = 0;
 
     var comment, match, key;
-debugger;
+
     reI18nComment.lastIndex = 0;
     this.reGetString.lastIndex = 0; // just to be safe
 

--- a/JavaScriptFileType.js
+++ b/JavaScriptFileType.js
@@ -104,7 +104,7 @@ var alreadyLocTmpl = new RegExp(/\.([a-z][a-z](-[A-Z][a-z][a-z][a-z])?(-[A-Z][A-
 JavaScriptFileType.prototype.handles = function(pathName) {
     this.logger.debug("JavaScriptFileType handles " + pathName + "?");
     var ret = false;
-debugger;
+
     // resource files should be handled by the JavaScriptResourceType instead
     if (this.project.isResourcePath("js", pathName)) return false;
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,11 @@ be localized, and the loctool will continue on to the next file.
 
 ## Release Notes
 
+### v1.1.1
+
+- deal with eslint's propensity of putting extra commas at the end of parameter lists
+  where they shouldn't be. This causes single-parameter strings not to be extracted.
+
 ### v1.1.0
 
 - added the ability to use ilib-loctool-json as a resource file

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     },
     "dependencies": {
         "ilib": "^14.14.0",
-        "ilib-loctool-javascript-resource": "^1.0.3"
+        "ilib-loctool-javascript-resource": "^1.0.4"
     },
     "devDependencies": {
         "assertextras": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-javascript",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "main": "./JavaScriptFileType.js",
     "description": "A loctool plugin that knows how to process JS files",
     "license": "Apache-2.0",

--- a/test/testJavaScriptFile.js
+++ b/test/testJavaScriptFile.js
@@ -1142,6 +1142,51 @@ module.exports.javascriptfile = {
         test.equal(r.getKey(), "Start \"Download");
 
         test.done();
-    }
+    },
 
+    testJavaScriptFileParseParametersWithExtraTrailingCommas: function(test) {
+        test.expect(9);
+
+        var j = new JavaScriptFile({
+            project: p,
+            pathName: undefined,
+            type: jsft
+        });
+        test.ok(j);
+
+        // eslint has this nasty habit of inserting useless extra commas at the end
+        // of parameter lists
+        j.parse(
+            "if (subcat === 'Has types') {\n" +
+            "    buttonText = RB.getStringJS(\n" +
+            "        'Start Download',\n" +
+            "    );\n" +
+            "    title = RB.getString(\n" +
+            "        'Types of {topic}',\n" +
+            "        'unique key',\n" +
+            "    )\n" +
+            "    .format({\n" +
+            "        topic: topic.attribute.name\n" +
+            "    });\n" +
+            "}\n"
+        );
+
+        var set = j.getTranslationSet();
+        test.ok(set);
+
+        var r = set.getBy({
+            reskey: "unique key"
+        });
+        test.ok(r);
+        test.equal(r.length, 1);
+        test.equal(r[0].getSource(), "Types of {topic}");
+        test.equal(r[0].getKey(), "unique key");
+
+        r = set.getBySource("Start Download");
+        test.ok(r);
+        test.equal(r.getSource(), "Start Download");
+        test.equal(r.getKey(), "Start Download");
+
+        test.done();
+    }
 };

--- a/test/testJavaScriptFile.js
+++ b/test/testJavaScriptFile.js
@@ -935,7 +935,34 @@ module.exports.javascriptfile = {
         });
         test.ok(j);
 
-        j.parse("var subcats = [RB.getStringJS(''), RB.getString(''), RB.getStringJS('', 'foo'), RB.getStringJS('foo', '')];\n");
+        j.parse("var subcats = [RB.getStringJS(''), RB.getString(''), RB.getStringJS('', 'foo')];\n");
+
+        var set = j.getTranslationSet();
+        test.ok(set);
+
+        test.equal(set.size(), 0);
+
+        test.done();
+    },
+
+    testJavaScriptFileParseNonString: function(test) {
+        test.expect(3);
+
+        var j = new JavaScriptFile({
+            project: p,
+            pathName: undefined,
+            type: jsft
+        });
+        test.ok(j);
+
+        j.parse("var subcats = [\n" +
+        "    RB.getStringJS(variableName),\n" +
+        "    RB.getString(undefined),\n" +
+        "    RB.getStringJS(variableName, 'foo')\n" +
+        "    RB.getString(function(x) {\n" +
+        "       return foo.getId(x);\n" +
+        "    }),\n" +
+        "];\n");
 
         var set = j.getTranslationSet();
         test.ok(set);


### PR DESCRIPTION
- deal with eslint's propensity of putting extra commas at the end of parameter lists where they shouldn't be. This causes both single- and double-parameter strings not to be extracted properly.
- also removed debugger; statements that should not have been there!